### PR TITLE
Fix missing quote in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -112,8 +112,7 @@ async def generate_ideas(user_entries: list, category: str) -> str:
         return f"אין לך עדיין רשומות בקטגוריית '{category}'. כתוב לי כמה דברים קודם!"
     
     # משתמש בכל הרעיונות, לא רק ב-20 הראשונים
-    entries_text = "
-".join([f"- {entry['content']}" for entry in user_entries])
+    entries_text = "\n".join([f"- {entry['content']}" for entry in user_entries])
     
     # פרומפט משופר שמדגיש הישארות נאמן לסגנון
     prompt = f"""על בסיס כל הרעיונות שלי בקטגוריית '{category}':
@@ -128,7 +127,7 @@ async def generate_ideas(user_entries: list, category: str) -> str:
 - השתמש באותו סוג מילים וביטויים
 - הרעיונות צריכים להרגיש כאילו אני כתבתי אותם
 
-כתוב 3 רעיونות בעברית ידידותית."""
+כתוב 3 רעיונות בעברית ידידותית."""
 
     try:
         response = await openai_client.chat.completions.create(


### PR DESCRIPTION
Fix malformed string literal and a typo in `main.py`.

The `entries_text` string was missing a closing quote, causing a syntax error. A minor typo in the prompt was also corrected.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a72554c-6acb-4e97-9583-10c5ad5e7584">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a72554c-6acb-4e97-9583-10c5ad5e7584">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>