### PR TITLE
Add delay to stale lock handling

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,7 +36,8 @@ def create_lock():
                 logger.error(f"🔒 Bot already running (PID: {old_pid}). Exiting.")
                 sys.exit(1)
             else:
-                logger.warning("⚠️ Stale lock file found for a non-running process. Overwriting.")
+                logger.warning("⚠️ Stale lock file found. Waiting 5 seconds before overwriting...")
+                time.sleep(5)  # Give Telegram time to timeout the old connection
         except (ValueError, FileNotFoundError):
              logger.warning("⚠️ Lock file is invalid. Overwriting.")
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add a 5-second delay before overwriting stale lock files to prevent Telegram `Conflict` errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-b1d932bd-aff0-458a-88c2-a5627bebda9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b1d932bd-aff0-458a-88c2-a5627bebda9d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>