### PR TITLE
Add startup delay to prevent conflicts

### DIFF
--- a/main.py
+++ b/main.py
@@ -507,6 +507,10 @@ def run_scheduled_job():
 
 if __name__ == "__main__":
     create_lock()
+
+    # --- Strategic delay to allow old Telegram connections to time out on Render ---
+    logger.info("Initial startup delay. Waiting 7 seconds...")
+    time.sleep(7)
     
     logger.info(f"Starting application in '{RUN_MODE}' mode.")
     


### PR DESCRIPTION
Add a 7-second startup delay in `main.py` to prevent `Conflict` errors from old Telegram connections on Render.

---
<a href="https://cursor.com/background-agent?bcId=bc-7db56a9e-bef5-4967-88a8-6f821e0e4c26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7db56a9e-bef5-4967-88a8-6f821e0e4c26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>